### PR TITLE
Refactored for easier testing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,15 +56,15 @@ Command-Line Tool pylddwrap
 
 .. code-block:: text
 
-    soname          | path                                  | found | mem_address          | unused
-    ----------------+---------------------------------------+-------+----------------------+-------
-    linux-vdso.so.1 | None                                  | True  | (0x00007ffd8750f000) | False
-    libselinux.so.1 | /lib/x86_64-linux-gnu/libselinux.so.1 | True  | (0x00007f4e73dc3000) | True
-    libc.so.6       | /lib/x86_64-linux-gnu/libc.so.6       | True  | (0x00007f4e739f9000) | False
-    libpcre.so.3    | /lib/x86_64-linux-gnu/libpcre.so.3    | True  | (0x00007f4e73789000) | False
-    libdl.so.2      | /lib/x86_64-linux-gnu/libdl.so.2      | True  | (0x00007f4e73585000) | False
-    None            | /lib64/ld-linux-x86-64.so.2           | True  | (0x00007f4e73fe5000) | False
-    libpthread.so.0 | /lib/x86_64-linux-gnu/libpthread.so.0 | True  | (0x00007f4e73368000) | False
+    soname          | path                                  | found | mem_address        | unused
+    ----------------+---------------------------------------+-------+--------------------+-------
+    linux-vdso.so.1 | None                                  | True  | 0x00007ffd8750f000 | False
+    libselinux.so.1 | /lib/x86_64-linux-gnu/libselinux.so.1 | True  | 0x00007f4e73dc3000 | True
+    libc.so.6       | /lib/x86_64-linux-gnu/libc.so.6       | True  | 0x00007f4e739f9000 | False
+    libpcre.so.3    | /lib/x86_64-linux-gnu/libpcre.so.3    | True  | 0x00007f4e73789000 | False
+    libdl.so.2      | /lib/x86_64-linux-gnu/libdl.so.2      | True  | 0x00007f4e73585000 | False
+    None            | /lib64/ld-linux-x86-64.so.2           | True  | 0x00007f4e73fe5000 | False
+    libpthread.so.0 | /lib/x86_64-linux-gnu/libpthread.so.0 | True  | 0x00007f4e73368000 | False
 
 
 * To obtain the dependencies as JSON, invoke:
@@ -82,7 +82,7 @@ Command-Line Tool pylddwrap
       "soname": "linux-vdso.so.1",
       "path": "None",
       "found": true,
-      "mem_address": "(0x00007ffed857f000)",
+      "mem_address": "0x00007ffed857f000",
       "unused": false
     },
     ...

--- a/pylint.rc
+++ b/pylint.rc
@@ -7,4 +7,4 @@ generated-members=bottle\.request\.forms\.decode,bottle\.request\.query\.decode
 max-line-length=80
 
 [MESSAGES CONTROL]
-disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,no-else-return
+disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,no-else-return,duplicate-code

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,59 @@
 """Test lddwrap."""
+
+import os
+import shlex
+import tempfile
+import textwrap
+from typing import Optional
+
+
+class MockLdd:
+    """Manage context for a mock ldd script."""
+
+    def __init__(self, out: str, out_unused: str) -> None:
+        self._tmpdir = None  # type: Optional[tempfile.TemporaryDirectory]
+        self.out = out
+        self.out_unused = out_unused
+        self._old_path = None  # type: Optional[str]
+
+    def __enter__(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+        # Create a mock bach script called ``ldd`` based on
+        # https://github.com/lattera/glibc/blob/master/elf/ldd.bash.in
+        script = textwrap.dedent('''\
+        #!/usr/bin/env bash
+        if [ $# -eq 1 ]; then
+            echo {out}
+        elif [ "$1" = "--unused" ]; then
+            echo {out_unused}
+
+            # Return code 1 implies at least one unused dependency.
+            exit 1
+        else
+            >&2 echo '$0 is: ' $0
+            >&2 echo '$1 is: ' $1
+            >&2 echo '$2 is: ' $2
+            >&2 echo "Unhandled command line arguments (count: $#): $@"
+            exit 1984
+        fi
+        '''.format(
+            out=shlex.quote(self.out), out_unused=shlex.quote(self.out_unused)))
+
+        pth = os.path.join(self._tmpdir.name, 'ldd')
+        with open(pth, 'wt') as fid:
+            fid.write(script)
+
+        os.chmod(pth, 0o700)
+
+        self._old_path = os.environ.get('PATH', None)
+
+        os.environ['PATH'] = (self._tmpdir.name if self._old_path is None else
+                              self._tmpdir.name + os.pathsep + self._old_path)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._tmpdir.cleanup()
+        if self._old_path is None:
+            del os.environ['PATH']
+        else:
+            os.environ['PATH'] = self._old_path

--- a/tests/test_ldd.py
+++ b/tests/test_ldd.py
@@ -2,22 +2,50 @@
 """Test lddwrap."""
 # pylint: disable=missing-docstring,too-many-public-methods
 import pathlib
+import textwrap
 import unittest
-from typing import Optional
+from typing import Any, List, Optional
 
 import lddwrap
+import tests
 
 
-def dependencies_equal(dep: lddwrap.Dependency,
-                       other: lddwrap.Dependency) -> bool:
-    # Do not compare mem_address as it can differ between machines.
-    return dep.soname == other.soname and \
-           dep.path == other.path and \
-           dep.found == other.found and \
-           dep.unused == other.unused
+class DependencyDiff:
+    """Represent a different between two dependencies."""
+
+    def __init__(self, attribute: str, ours: Any, theirs: Any) -> None:
+        self.attribute = attribute
+        self.ours = ours
+        self.theirs = theirs
+
+    def __repr__(self) -> str:
+        return "DependencyDiff(attribute={!r}, ours={!r}, theirs={!r})".format(
+            self.attribute, self.ours, self.theirs)
 
 
-class TestLdd(unittest.TestCase):
+def diff_dependencies(ours: lddwrap.Dependency,
+                      theirs: lddwrap.Dependency) -> List[DependencyDiff]:
+    """
+    Compare two dependencies and give their differences in a list.
+
+    An empty list means no difference.
+    """
+    keys = sorted(ours.__dict__.keys())
+    assert keys == sorted(theirs.__dict__.keys())
+
+    result = []  # type: List[DependencyDiff]
+    for key in keys:
+        if ours.__dict__[key] != theirs.__dict__[key]:
+            result.append(
+                DependencyDiff(
+                    attribute=key,
+                    ours=ours.__dict__[key],
+                    theirs=theirs.__dict__[key]))
+
+    return result
+
+
+class TestParseOutputWithoutUnused(unittest.TestCase):
     def test_parse_line(self):
         # yapf: disable
         lines = [
@@ -34,18 +62,19 @@ class TestLdd(unittest.TestCase):
             "/home/user/lib/liblmdb.so => not found"
         ]
         # yapf: enable
+
         expected_deps = [
             lddwrap.Dependency(
                 soname="libstdc++.so.6",
                 path=pathlib.Path("/usr/lib/x86_64-linux-gnu/libstdc++.so.6"),
                 found=True,
-                mem_address="",
+                mem_address="0x00007f9a19d8a000",
                 unused=None),
             lddwrap.Dependency(
                 soname=None,
                 path=pathlib.Path("/lib64/ld-linux-x86-64.so.2"),
                 found=True,
-                mem_address="",
+                mem_address="0x00007f9a1a329000",
                 unused=None),
             lddwrap.Dependency(
                 soname="libboost_program_options.so.1.62.0",
@@ -57,7 +86,7 @@ class TestLdd(unittest.TestCase):
                 soname="linux-vdso.so.1",
                 path=None,
                 found=True,
-                mem_address="",
+                mem_address="0x00007ffd7c7fd000",
                 unused=None),
             lddwrap.Dependency(
                 soname="libopencv_stitching.so.3.3",
@@ -69,7 +98,7 @@ class TestLdd(unittest.TestCase):
                 soname="libstdc++.so.6",
                 path=pathlib.Path("/usr/lib/x86_64-linux-gnu/libstdc++.so.6"),
                 found=True,
-                mem_address="",
+                mem_address="0x00007f4b78462000",
                 unused=None),
             lddwrap.Dependency(
                 soname="libz.so.1", path=None, found=False, mem_address=None),
@@ -91,10 +120,10 @@ class TestLdd(unittest.TestCase):
             # pylint: disable=protected-access
             dep = lddwrap._parse_line(line=line)
 
-            self.assertTrue(
-                dependencies_equal(dep, expected_deps[i]),
-                "Incorrect dependency read from the line {}, expected {}\n"
-                "got {}".format(line, expected_deps[i], dep))
+            self.assertListEqual(
+                [], diff_dependencies(ours=dep, theirs=expected_deps[i]),
+                "Incorrect dependency read from the line {} {!r}".format(
+                    i + 1, line))
 
     def test_parse_wrong_line(self):
         # ``parse_line`` raises a RuntimeError when it receives an unexpected
@@ -111,155 +140,173 @@ class TestLdd(unittest.TestCase):
             'Expected 2 parts in the line but found {}: {}'.format(
                 line.count(' ') + 1, line), str(run_err))
 
+
+class TestAgainstMockLdd(unittest.TestCase):
     def test_pwd(self):
-        path = pathlib.Path("/bin/pwd")
-        deps = lddwrap.list_dependencies(path=path)
+        """Test parsing the captured output  of ``ldd`` on ``/bin/pwd``."""
 
-        expected_deps = [
-            lddwrap.Dependency(
-                soname="linux-vdso.so.1",
-                path=None,
-                found=True,
-                mem_address="",
-                unused=None),
-            lddwrap.Dependency(
-                soname="libc.so.6",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libc.so.6"),
-                found=True,
-                mem_address="",
-                unused=None),
-            lddwrap.Dependency(
-                soname=None,
-                path=pathlib.Path("/lib64/ld-linux-x86-64.so.2"),
-                found=True,
-                mem_address="",
-                unused=None)
-        ]
+        with tests.MockLdd(
+                out=textwrap.dedent('''\
+            \tlinux-vdso.so.1 (0x00007ffe0953f000)
+            \tlibc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fd548353000)
+            \t/lib64/ld-linux-x86-64.so.2 (0x00007fd54894d000)\n'''),
+                out_unused=''):
+            deps = lddwrap.list_dependencies(
+                path=pathlib.Path('/bin/pwd'), unused=False)
 
-        for dep in deps:
-            for exp_dep in expected_deps:
-                if exp_dep.soname == dep.soname:
-                    self.assertTrue(
-                        dependencies_equal(dep, exp_dep),
-                        "Incorrect dependency, expected {}\ngot {}".format(
-                            exp_dep, dep))
-                    break
+            expected_deps = [
+                lddwrap.Dependency(
+                    soname="linux-vdso.so.1",
+                    path=None,
+                    found=True,
+                    mem_address="0x00007ffe0953f000",
+                    unused=None),
+                lddwrap.Dependency(
+                    soname='libc.so.6',
+                    path=pathlib.Path("/lib/x86_64-linux-gnu/libc.so.6"),
+                    found=True,
+                    mem_address="0x00007fd548353000",
+                    unused=None),
+                lddwrap.Dependency(
+                    soname=None,
+                    path=pathlib.Path("/lib64/ld-linux-x86-64.so.2"),
+                    found=True,
+                    mem_address="0x00007fd54894d000",
+                    unused=None)
+            ]
 
-    def test_dir(self):
-        path = pathlib.Path("/bin/dir")
-        deps = lddwrap.list_dependencies(path=path)
+            self.assertEqual(len(expected_deps), len(deps))
 
-        expected_deps = [
-            lddwrap.Dependency(
-                soname="linux-vdso.so.1",
-                path=None,
-                found=True,
-                mem_address="",
-                unused=None),
-            lddwrap.Dependency(
-                soname="libselinux.so.1",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libselinux.so.1"),
-                found=True,
-                mem_address="",
-                unused=None),
-            lddwrap.Dependency(
-                soname="libc.so.6",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libc.so.6"),
-                found=True,
-                mem_address="",
-                unused=None),
-            lddwrap.Dependency(
-                soname="libpcre.so.3",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libpcre.so.3"),
-                found=True,
-                mem_address="",
-                unused=None),
-            lddwrap.Dependency(
-                soname="libdl.so.2",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libdl.so.2"),
-                found=True,
-                mem_address="",
-                unused=None),
-            lddwrap.Dependency(
-                soname=None,
-                path=pathlib.Path("/lib64/ld-linux-x86-64.so.2"),
-                found=True,
-                mem_address="",
-                unused=None),
-            lddwrap.Dependency(
-                soname="libpthread.so.0",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libpthread.so.0"),
-                found=True,
-                mem_address="",
-                unused=None)
-        ]
+            for i, (dep, expected_dep) in enumerate(zip(deps, expected_deps)):
+                self.assertListEqual([],
+                                     diff_dependencies(
+                                         ours=dep, theirs=expected_dep),
+                                     "Mismatch at the dependency {}".format(i))
 
-        for dep in deps:
-            for exp_dep in expected_deps:
-                if exp_dep.soname == dep.soname:
-                    self.assertTrue(
-                        dependencies_equal(dep, exp_dep),
-                        "Incorrect dependency, expected {}\ngot {}".format(
-                            exp_dep, dep))
-                    break
+    def test_bin_dir(self):
+        """Test parsing the captured output  of ``ldd`` on ``/bin/dir``."""
 
-    def test_dir_unused(self):
-        path = pathlib.Path("/bin/dir")
-        deps = lddwrap.list_dependencies(path=path, unused=True)
+        #pylint: disable=line-too-long
+        with tests.MockLdd(
+                out=textwrap.dedent('''\
+                    \tlinux-vdso.so.1 (0x00007ffd66ce2000)
+                    \tlibselinux.so.1 => /lib/x86_64-linux-gnu/libselinux.so.1 (0x00007f72b88fc000)
+                    \tlibc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f72b850b000)
+                    \tlibpcre.so.3 => /lib/x86_64-linux-gnu/libpcre.so.3 (0x00007f72b8299000)
+                    \tlibdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f72b8095000)
+                    \t/lib64/ld-linux-x86-64.so.2 (0x00007f72b8d46000)
+                    \tlibpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f72b7e76000)\n'''
+                                    ),
+                out_unused=''):
+            # pylint: enable=line-too-long
+            deps = lddwrap.list_dependencies(
+                path=pathlib.Path('/bin/dir'), unused=False)
 
-        expected_deps = [
-            lddwrap.Dependency(
-                soname="linux-vdso.so.1",
-                path=None,
-                found=True,
-                mem_address="",
-                unused=False),
-            lddwrap.Dependency(
-                soname="libselinux.so.1",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libselinux.so.1"),
-                found=True,
-                mem_address="",
-                unused=True),
-            lddwrap.Dependency(
-                soname="libc.so.6",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libc.so.6"),
-                found=True,
-                mem_address="",
-                unused=False),
-            lddwrap.Dependency(
-                soname="libpcre.so.3",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libpcre.so.3"),
-                found=True,
-                mem_address="",
-                unused=False),
-            lddwrap.Dependency(
-                soname="libdl.so.2",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libdl.so.2"),
-                found=True,
-                mem_address="",
-                unused=False),
-            lddwrap.Dependency(
-                soname=None,
-                path=pathlib.Path("/lib64/ld-linux-x86-64.so.2"),
-                found=True,
-                mem_address="",
-                unused=False),
-            lddwrap.Dependency(
-                soname="libpthread.so.0",
-                path=pathlib.Path("/lib/x86_64-linux-gnu/libpthread.so.0"),
-                found=True,
-                mem_address="",
-                unused=False)
-        ]
+            expected_deps = [
+                lddwrap.Dependency(
+                    soname="linux-vdso.so.1",
+                    path=None,
+                    found=True,
+                    mem_address="0x00007ffd66ce2000",
+                    unused=None),
+                lddwrap.Dependency(
+                    soname="libselinux.so.1",
+                    path=pathlib.Path("/lib/x86_64-linux-gnu/libselinux.so.1"),
+                    found=True,
+                    mem_address="0x00007f72b88fc000",
+                    unused=None),
+                lddwrap.Dependency(
+                    soname="libc.so.6",
+                    path=pathlib.Path("/lib/x86_64-linux-gnu/libc.so.6"),
+                    found=True,
+                    mem_address="0x00007f72b850b000",
+                    unused=None),
+                lddwrap.Dependency(
+                    soname="libpcre.so.3",
+                    path=pathlib.Path("/lib/x86_64-linux-gnu/libpcre.so.3"),
+                    found=True,
+                    mem_address="0x00007f72b8299000",
+                    unused=None),
+                lddwrap.Dependency(
+                    soname="libdl.so.2",
+                    path=pathlib.Path("/lib/x86_64-linux-gnu/libdl.so.2"),
+                    found=True,
+                    mem_address="0x00007f72b8095000",
+                    unused=None),
+                lddwrap.Dependency(
+                    soname=None,
+                    path=pathlib.Path("/lib64/ld-linux-x86-64.so.2"),
+                    found=True,
+                    mem_address="0x00007f72b8d46000",
+                    unused=None),
+                lddwrap.Dependency(
+                    soname="libpthread.so.0",
+                    path=pathlib.Path("/lib/x86_64-linux-gnu/libpthread.so.0"),
+                    found=True,
+                    mem_address="0x00007f72b7e76000",
+                    unused=None),
+            ]
 
-        for dep in deps:
-            for exp_dep in expected_deps:
-                if exp_dep.soname == dep.soname:
-                    self.assertTrue(
-                        dependencies_equal(dep, exp_dep),
-                        "Incorrect dependency, expected {}\ngot {}".format(
-                            exp_dep, dep))
-                    break
+            self.assertEqual(len(expected_deps), len(deps))
+
+            for i, (dep, expected_dep) in enumerate(zip(deps, expected_deps)):
+                self.assertListEqual([],
+                                     diff_dependencies(
+                                         ours=dep, theirs=expected_dep),
+                                     "Mismatch at the dependency {}".format(i))
+
+    def test_bin_dir_with_empty_unused(self):
+        # pylint: disable=line-too-long
+        with tests.MockLdd(
+                out=textwrap.dedent('''\
+                            \tlinux-vdso.so.1 (0x00007ffd66ce2000)
+                            \tlibselinux.so.1 => /lib/x86_64-linux-gnu/libselinux.so.1 (0x00007f72b88fc000)
+                            \tlibc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f72b850b000)
+                            \tlibpcre.so.3 => /lib/x86_64-linux-gnu/libpcre.so.3 (0x00007f72b8299000)
+                            \tlibdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f72b8095000)
+                            \t/lib64/ld-linux-x86-64.so.2 (0x00007f72b8d46000)
+                            \tlibpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f72b7e76000)\n'''
+                                    ),
+                out_unused=''):
+            # pylint: enable=line-too-long
+            deps = lddwrap.list_dependencies(
+                path=pathlib.Path("/bin/dir"), unused=True)
+
+            unused = [dep for dep in deps if dep.unused]
+            self.assertListEqual([], unused)
+
+    def test_with_fantasy_unused(self):
+        """Test against a fantasy executable with fantasy unused."""
+        # pylint: disable=line-too-long
+        with tests.MockLdd(
+                out=textwrap.dedent('''\
+                            \tlinux-vdso.so.1 (0x00007ffd66ce2000)
+                            \tlibm.so.6 => /lib64/libm.so.6 (0x00007f72b7e76000)\n'''
+                                    ),
+                out_unused=textwrap.dedent('''\
+                    Unused direct dependencies:
+                    \t/lib64/libm.so.6\n''')):
+            # pylint: enable=line-too-long
+            deps = lddwrap.list_dependencies(
+                path=pathlib.Path("/bin/dir"), unused=True)
+
+            unused = [dep for dep in deps if dep.unused]
+
+            expected_unused = [
+                lddwrap.Dependency(
+                    soname="libm.so.6",
+                    path=pathlib.Path("/lib64/libm.so.6"),
+                    found=True,
+                    mem_address="0x00007f72b7e76000",
+                    unused=True)
+            ]
+
+            self.assertEqual(len(expected_unused), len(unused))
+
+            for i, (dep, exp_dep) in enumerate(zip(unused, expected_unused)):
+                self.assertListEqual(
+                    [], diff_dependencies(ours=dep, theirs=exp_dep),
+                    "Mismatch at the unused dependency {}".format(i))
 
 
 if __name__ == '__main__':

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,14 +6,15 @@ import json
 import pathlib
 import textwrap
 import unittest
-from typing import TextIO, cast
+from typing import List, TextIO, cast
 
 import lddwrap
 import lddwrap.main
 import pylddwrap_meta
-
-
 # pylint: disable=missing-docstring
+import tests
+
+
 class TestParseArgs(unittest.TestCase):
     def test_single_path(self):
         args = lddwrap.main.parse_args(
@@ -118,25 +119,27 @@ class TestMain(unittest.TestCase):
         args = lddwrap.main.parse_args(
             sys_argv=["some-executable.py", "/bin/pwd"])
 
-        retcode = lddwrap.main._main(args=args, stream=stream)
+        with tests.MockLdd(
+                out=textwrap.dedent('''\
+            \tlinux-vdso.so.1 (0x00007ffe0953f000)
+            \tlibc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fd548353000)
+            \t/lib64/ld-linux-x86-64.so.2 (0x00007fd54894d000)\n'''),
+                out_unused=''):
 
-        self.assertEqual(0, retcode)
-        # pylint: disable=trailing-whitespace
-        expected_output = textwrap.dedent("""\
-        soname          | path                            | found | mem_address          | unused
-        ----------------+---------------------------------+-------+----------------------+-------
-        linux-vdso.so.1 | None                            | True  | (0x00007ffc019df000) | False 
-        libc.so.6       | /lib/x86_64-linux-gnu/libc.so.6 | True  | (0x00007f3105ea4000) | False 
-        None            | /lib64/ld-linux-x86-64.so.2     | True  | (0x00007f310626e000) | False 
-        """)
-        output = textwrap.dedent(buf.getvalue())
+            retcode = lddwrap.main._main(args=args, stream=stream)
 
-        count_diff = 0
-        for char_expected, char_output in zip(expected_output, output):
-            if char_expected != char_output:
-                count_diff += 1
-        # the memory address changes -> 3 times 16 chars are different
-        self.assertLessEqual(count_diff, 16 * 3)
+            self.assertEqual(0, retcode)
+            # pylint: disable=trailing-whitespace
+            expected_output = textwrap.dedent("""\
+            soname          | path                            | found | mem_address        | unused
+            ----------------+---------------------------------+-------+--------------------+-------
+            linux-vdso.so.1 | None                            | True  | 0x00007ffe0953f000 | False 
+            libc.so.6       | /lib/x86_64-linux-gnu/libc.so.6 | True  | 0x00007fd548353000 | False 
+            None            | /lib64/ld-linux-x86-64.so.2     | True  | 0x00007fd54894d000 | False 
+            """)
+            output = textwrap.dedent(buf.getvalue())
+
+            self.assertEqual(expected_output, output)
 
     def test_version(self):
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
The current code depdended completely on the platform as it performed
live tests in the unit testing code. This patch refactors the
test code to create a mock `ldd` script which is executed instead of
the actual script.

A few minor bugs were uncovered and were fixed (brackets around
the memory address and special case of VDSO).