### PR TITLE
Added `--sorted` command-line option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,38 @@ Command-Line Tool pylddwrap
     ...
   ]
 
+* You can also sort the table with ``--sorted`` which will sort by ``soname``:
+
+.. code-block:: bash
+
+    pylddwrap /bin/pwd --sorted
+
+* Pylddwrap gives the table sorted by ``soname``:
+
+.. code-block:: text
+
+    soname          | path                            | found | mem_address        | unused
+    ----------------+---------------------------------+-------+--------------------+-------
+    None            | /lib64/ld-linux-x86-64.so.2     | True  | 0x00007fd54894d000 | False
+    libc.so.6       | /lib/x86_64-linux-gnu/libc.so.6 | True  | 0x00007fd548353000 | False
+    linux-vdso.so.1 | None                            | True  | 0x00007ffe0953f000 | False
+
+Alternatively, you can sort by any other column. For example, to sort
+by ``path``:
+
+.. code-block:: bash
+
+    pylddwrap /bin/pwd --sorted path
+
+* The output will be:
+
+.. code-block:: text
+
+    soname          | path                            | found | mem_address        | unused
+    ----------------+---------------------------------+-------+--------------------+-------
+    linux-vdso.so.1 | None                            | True  | 0x00007ffe0953f000 | False
+    libc.so.6       | /lib/x86_64-linux-gnu/libc.so.6 | True  | 0x00007fd548353000 | False
+    None            | /lib64/ld-linux-x86-64.so.2     | True  | 0x00007fd54894d000 | False
 
 
 ldwrap Python Module

--- a/lddwrap/__init__.py
+++ b/lddwrap/__init__.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Mapping, Optional, TextIO
 
 import icontract
 
+DEPENDENCY_ATTRIBUTES = ['soname', 'path', 'found', 'mem_address', 'unused']
+
 
 # yapf: disable
 @icontract.invariant(
@@ -46,6 +48,10 @@ class Dependency:
     :vartype unused: Optional[bool]
     """
 
+    @icontract.ensure(
+        lambda self: all(hasattr(self, col) for col in DEPENDENCY_ATTRIBUTES),
+        "All expected attributes are present so that "
+        "lists of dependencies can be sorted dynamically")
     def __init__(self,
                  found: bool,
                  soname: Optional[str] = None,


### PR DESCRIPTION
This patch introduces the command-line option `--sorted` to allow for
sorting the output by an attribute of the dependency.

This is further development of the initial pull request #5.