### PR TITLE
Added handling of static libraries

### DIFF
--- a/lddwrap/__init__.py
+++ b/lddwrap/__init__.py
@@ -252,10 +252,18 @@ def _cmd_output_parser(cmd_out: str) -> List[Dependency]:
     """
     dependencies = []  # type: List[Dependency]
 
-    for line in [
-            line.strip() for line in cmd_out.split('\n') if line.strip() != ''
-    ]:
+    lines = [line.strip() for line in cmd_out.split('\n') if line.strip() != '']
 
+    if len(lines) == 0:
+        return []
+
+    # This is a special case of a static library. The first line refers
+    # to the library and the second line indicates that the library
+    # was statically linked.
+    if len(lines) == 2 and lines[1] == 'statically linked':
+        return []
+
+    for line in lines:
         dep = _parse_line(line=line)
         if dep is not None:
             dependencies.append(dep)

--- a/tests/test_ldd.py
+++ b/tests/test_ldd.py
@@ -2,6 +2,7 @@
 """Test lddwrap."""
 # pylint: disable=missing-docstring,too-many-public-methods
 import pathlib
+import tempfile
 import textwrap
 import unittest
 from typing import Any, List, Optional
@@ -139,6 +140,17 @@ class TestParseOutputWithoutUnused(unittest.TestCase):
         self.assertEqual(
             'Expected 2 parts in the line but found {}: {}'.format(
                 line.count(' ') + 1, line), str(run_err))
+
+    def test_parse_static(self) -> None:
+        """Test parsing of the output when we ldd a static library."""
+        # pylint: disable=protected-access
+        deps = lddwrap._cmd_output_parser(
+            textwrap.dedent('''\
+            my_static_lib.so:
+                statically linked
+            '''))
+
+        self.assertListEqual([], deps)
 
 
 class TestAgainstMockLdd(unittest.TestCase):
@@ -307,6 +319,24 @@ class TestAgainstMockLdd(unittest.TestCase):
                 self.assertListEqual(
                     [], diff_dependencies(ours=dep, theirs=exp_dep),
                     "Mismatch at the unused dependency {}".format(i))
+
+    def test_with_static_library(self) -> None:
+        """Test against a fantasy static library."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            lib_pth = pathlib.Path(tmp_dir) / "my_static_lib.so"
+            lib_pth.write_text("totally static!")
+
+            with tests.MockLdd(
+                    out=textwrap.dedent('''\
+                                my_static_lib.so:
+                                \tstatically linked\n'''),
+                    out_unused=''):
+                # pylint: enable=line-too-long
+                deps = lddwrap.list_dependencies(path=lib_pth, unused=True)
+
+                # The dependencies are empty since the library is
+                # statically linked.
+                self.assertListEqual([], deps)
 
 
 class TestSorting(unittest.TestCase):


### PR DESCRIPTION
Static libraries are a special case for `ldd` where it simply returns a
message "statically linked". This patch handles this special case in
pylddwrap as well.

Fixes #12.