### PR TITLE
Ignore not-indented ldd output

### DIFF
--- a/lddwrap/__init__.py
+++ b/lddwrap/__init__.py
@@ -252,7 +252,11 @@ def _cmd_output_parser(cmd_out: str) -> List[Dependency]:
     """
     dependencies = []  # type: List[Dependency]
 
-    lines = [line.strip() for line in cmd_out.split('\n') if line.strip() != '']
+    lines = [
+        line.strip()
+        for line in cmd_out.split('\n')
+        if line.startswith(' ') and line.strip() != ''
+    ]
 
     if len(lines) == 0:
         return []


### PR DESCRIPTION
The first line of this output caused the exception below.

```console
$ ldd qt/6.0.2/gcc_64/plugins/sqldrivers/libqsqlpsql.so
qt/6.0.2/gcc_64/plugins/sqldrivers/libqsqlpsql.so: /lib/x86_64-linux-gnu/libpq.so.5: no version information available (required by qt/6.0.2/gcc_64/plugins/sqldrivers/libqsqlpsql.so)
        linux-vdso.so.1 (0x00007fffd2f0d000)
        libpq.so.5 => /lib/x86_64-linux-gnu/libpq.so.5 (0x00007ff5a9a5a000)
        libQt6Sql.so.6 => /home/altendky/repos/qt-applications/qt/6.0.2/gcc_64/plugins/sqldrivers/../../lib/libQt6Sql.so.6 (0x00007ff5a980b000)
        libQt6Core.so.6 => /home/altendky/repos/qt-applications/qt/6.0.2/gcc_64/plugins/sqldrivers/../../lib/libQt6Core.so.6 (0x00007ff5a9001000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007ff5a8fde000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007ff5a8dfd000)

<snip>
```

Long winded traceback redacted by removing piles of wheel-building layers.

```python-traceback
  Traceback (most recent call last):                                                                                                                                                                                              

<snip>

    File "./build.py", line 218, in linuxdeployqt_substitute_list_source
      for dependency in lddwrap.list_dependencies(
    File "/tmp/pip-build-env-ueu0a2p1/overlay/lib/python3.9/site-packages/icontract/_checkers.py", line 648, in wrapper
      result = func(*args, **kwargs)
    File "/tmp/pip-build-env-ueu0a2p1/overlay/lib/python3.9/site-packages/lddwrap/__init__.py", line 220, in list_dependencies
      dependencies = _cmd_output_parser(cmd_out=out)  # type: List[Dependency]
    File "/tmp/pip-build-env-ueu0a2p1/overlay/lib/python3.9/site-packages/lddwrap/__init__.py", line 259, in _cmd_output_parser
      dep = _parse_line(line=line)
    File "/tmp/pip-build-env-ueu0a2p1/overlay/lib/python3.9/site-packages/lddwrap/__init__.py", line 165, in _parse_line
      raise RuntimeError(
  RuntimeError: Expected 2 parts in the line but found 9: /tmp/pip-req-build-lyab9hdl/build/qt_applications-t5l6p3ia/qt/6.0.2/gcc_64/plugins/sqldrivers/libqsqlpsql.so: /lib/x86_64-linux-gnu/libpq.so.5: no version information available (required by /tmp/pip-req-build-lyab9hdl/build/qt_applications-t5l6p3ia/qt/6.0.2/gcc_64/plugins/sqldrivers/libqsqlpsql.so)
```