### PR TITLE
Removed support for Python 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,6 @@ jobs:
           - name: Linux
             runs-on: ubuntu-latest
         python:
-          - name: CPython 3.5
-            tox: py35
-            action: 3.5
           - name: CPython 3.6
             tox: py36
             action: 3.6

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -46,7 +45,7 @@ setup(
     license='License :: OSI Approved :: MIT License',
     keywords='ldd dependency dependencies lddwrap pylddwrap',
     packages=find_packages(exclude=['tests']),
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=install_requires,
     extras_require={
         'dev': [


### PR DESCRIPTION
Python 3.5 reached its end-of-life in 2020. One of the dependencies,
icontract, already dropped the support for it, so we propagate the
change to this project as well.