### PR TITLE
Bumped to 1.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.2.1
+=====
+* Removed support for Python 3.5 (#23)
+* Improved support of statically linked libraries (#22)
+
 1.2.0
 =====
 * Ignore not-indented ldd output (#14)

--- a/pylddwrap_meta.py
+++ b/pylddwrap_meta.py
@@ -4,7 +4,7 @@
 __title__ = 'pylddwrap'
 __description__ = 'Wrap ldd *nix utility to determine shared libraries required by a program.'
 __url__ = 'http://github.com/Parquery/lddwrap'
-__version__ = '1.2.0'  # don't forget to update the changelog!
+__version__ = '1.2.1'  # don't forget to update the changelog!
 __author__ = 'Selim Naji, Adam Radomski and Marko Ristin'
 __author_email__ = 'selim.naji@parquery.com, adam.radomski@parquery.com, marko.ristin@gmail.com'
 __license__ = 'MIT'


### PR DESCRIPTION
* Removed support for Python 3.5 (#23)
* Improved support of statically linked libraries (#22)