### PR TITLE
Added support for paths with spaces

### DIFF
--- a/lddwrap/__init__.py
+++ b/lddwrap/__init__.py
@@ -94,6 +94,7 @@ _LDD_NON_ARROW_OUTPUT_RE = re.compile(
     r"(?P<dep_path>.+)\s\(?(?P<mem_address>\w*)\)?")
 
 
+# pylint: disable=too-many-branches
 def _parse_line(line: str) -> Optional[Dependency]:
     """
     Parse single line of ldd output.
@@ -132,8 +133,8 @@ def _parse_line(line: str) -> Optional[Dependency]:
                 mem_address = mtch["mem_address"]
         else:
             if os.sep in mtch["soname"]:
-                # This is a special case where the dep_path comes before the arrow
-                # and we have no soname
+                # This is a special case where the dep_path comes before the
+                # arrow and we have no soname
                 dep_path = pathlib.Path(mtch["soname"])
             else:
                 soname = mtch["soname"]

--- a/lddwrap/__init__.py
+++ b/lddwrap/__init__.py
@@ -88,8 +88,10 @@ class Dependency:
                                         ("unused", self.unused)])
 
 
-_LDD_ARROW_OUTPUT_RE = re.compile(r"(?P<soname>.+)\s=>\s(?P<dep_path>.*)\s\(?(?P<mem_address>\w*)\)?")
-_LDD_NON_ARROW_OUTPUT_RE = re.compile(r"(?P<dep_path>.+)\s\(?(?P<mem_address>\w*)\)?")
+_LDD_ARROW_OUTPUT_RE = re.compile(
+    r"(?P<soname>.+)\s=>\s(?P<dep_path>.*)\s\(?(?P<mem_address>\w*)\)?")
+_LDD_NON_ARROW_OUTPUT_RE = re.compile(
+    r"(?P<dep_path>.+)\s\(?(?P<mem_address>\w*)\)?")
 
 
 def _parse_line(line: str) -> Optional[Dependency]:
@@ -119,9 +121,9 @@ def _parse_line(line: str) -> Optional[Dependency]:
     if '=>' in line:
         mtch = _LDD_ARROW_OUTPUT_RE.match(line)
         if not mtch:
-            raise RuntimeError(("Unexpected ldd output. Expect a regex match {}, "
-                                "but got: {!r}").format(_LDD_ARROW_OUTPUT_RE.pattern,
-                                                        line))
+            raise RuntimeError(
+                ("Unexpected ldd output. Expect a regex match {}, "
+                 "but got: {!r}").format(_LDD_ARROW_OUTPUT_RE.pattern, line))
         if found:
             soname = mtch["soname"]
             if mtch["dep_path"]:
@@ -142,9 +144,10 @@ def _parse_line(line: str) -> Optional[Dependency]:
 
         mtch = _LDD_NON_ARROW_OUTPUT_RE.match(line)
         if not mtch:
-            raise RuntimeError(("Unexpected ldd output. Expect a regex match {}, "
-                                "but got: {!r}").format(_LDD_NON_ARROW_OUTPUT_RE.pattern,
-                                                        line))
+            raise RuntimeError(
+                ("Unexpected ldd output. Expect a regex match {}, "
+                 "but got: {!r}").format(_LDD_NON_ARROW_OUTPUT_RE.pattern,
+                                         line))
         # Special case for linux-vdso
         if mtch["dep_path"].startswith("linux-vdso"):
             soname = mtch["dep_path"]
@@ -159,7 +162,8 @@ def _parse_line(line: str) -> Optional[Dependency]:
     if dep_path and os.sep not in str(dep_path):
         raise RuntimeError("Unexpected library path: {}".format(dep_path))
 
-    return Dependency(soname=soname, path=dep_path, found=found, mem_address=mem_address)
+    return Dependency(
+        soname=soname, path=dep_path, found=found, mem_address=mem_address)
 
 
 @icontract.require(lambda path: path.is_file())

--- a/lddwrap/__init__.py
+++ b/lddwrap/__init__.py
@@ -122,9 +122,9 @@ def _parse_line(line: str) -> Optional[Dependency]:
     if '=>' in line:
         mtch = _LDD_ARROW_OUTPUT_RE.match(line)
         if not mtch:
-            raise RuntimeError(
-                ("Unexpected ldd output. Expect a regex match {}, "
-                 "but got: {!r}").format(_LDD_ARROW_OUTPUT_RE.pattern, line))
+            raise RuntimeError(("Unexpected ldd output. Expected to match {}, "
+                                "but got: {!r}").format(
+                                    _LDD_ARROW_OUTPUT_RE.pattern, line))
         if found:
             soname = mtch["soname"]
             if mtch["dep_path"]:
@@ -145,10 +145,9 @@ def _parse_line(line: str) -> Optional[Dependency]:
 
         mtch = _LDD_NON_ARROW_OUTPUT_RE.match(line)
         if not mtch:
-            raise RuntimeError(
-                ("Unexpected ldd output. Expect a regex match {}, "
-                 "but got: {!r}").format(_LDD_NON_ARROW_OUTPUT_RE.pattern,
-                                         line))
+            raise RuntimeError(("Unexpected ldd output. Expected to match {}, "
+                                "but got: {!r}").format(
+                                    _LDD_NON_ARROW_OUTPUT_RE.pattern, line))
         # Special case for linux-vdso
         if mtch["dep_path"].startswith("linux-vdso"):
             soname = mtch["dep_path"]

--- a/tests/test_ldd.py
+++ b/tests/test_ldd.py
@@ -151,7 +151,7 @@ class TestParseOutputWithoutUnused(unittest.TestCase):
             run_err = err
 
         self.assertIsNotNone(run_err)
-        self.assertTrue(str(run_err).startswith("Unexpected mem address."))
+        self.assertTrue(str(run_err).startswith("Unexpected library path:"))
 
     def test_parse_non_indented_line(self):
         """Lines without leading indentation, at this point in processing, are

--- a/tests/test_ldd.py
+++ b/tests/test_ldd.py
@@ -62,7 +62,7 @@ class TestParseOutputWithoutUnused(unittest.TestCase):
             "../build/debug/libextstr.so => not found",
             "/home/user/lib/liblmdb.so => not found",
             "/home/u s e r/lib/liblmdb.so => not found",
-            "UnityPlayer.so => /home/user/games/q u d/./UnityPlayer.so"
+            "UnityPlayer.so => /home/user/games/q u d/./UnityPlayer.so "
             "(0x00007f90f290f000)"
         ]
         # yapf: enable

--- a/tests/test_ldd.py
+++ b/tests/test_ldd.py
@@ -60,7 +60,9 @@ class TestParseOutputWithoutUnused(unittest.TestCase):
             "(0x00007f4b78462000)",
             "libz.so.1 => not found",
             "../build/debug/libextstr.so => not found",
-            "/home/user/lib/liblmdb.so => not found"
+            "/home/user/lib/liblmdb.so => not found",
+            "/home/u s e r/lib/liblmdb.so => not found",
+            "UnityPlayer.so => /home/user/games/q u d/./UnityPlayer.so (0x00007f90f290f000)"
         ]
         # yapf: enable
 
@@ -114,7 +116,19 @@ class TestParseOutputWithoutUnused(unittest.TestCase):
                 path=pathlib.Path("/home/user/lib/liblmdb.so"),
                 found=False,
                 mem_address=None,
-                unused=None)
+                unused=None),
+            lddwrap.Dependency(
+                soname=None,
+                path=pathlib.Path("/home/u s e r/lib/liblmdb.so"),
+                found=False,
+                mem_address=None,
+                unused=None),
+            lddwrap.Dependency(
+                soname="UnityPlayer.so",
+                path=pathlib.Path("/home/user/games/q u d/./UnityPlayer.so"),
+                found=True,
+                mem_address="0x00007f90f290f000",
+                unused=None),
         ]
 
         for i, line in enumerate(lines):
@@ -137,9 +151,7 @@ class TestParseOutputWithoutUnused(unittest.TestCase):
             run_err = err
 
         self.assertIsNotNone(run_err)
-        self.assertEqual(
-            'Expected 2 parts in the line but found {}: {}'.format(
-                line.count(' ') + 1, line), str(run_err))
+        self.assertTrue(str(run_err).startswith("Unexpected mem address."))
 
     def test_parse_non_indented_line(self):
         """Lines without leading indentation, at this point in processing, are

--- a/tests/test_ldd.py
+++ b/tests/test_ldd.py
@@ -62,7 +62,8 @@ class TestParseOutputWithoutUnused(unittest.TestCase):
             "../build/debug/libextstr.so => not found",
             "/home/user/lib/liblmdb.so => not found",
             "/home/u s e r/lib/liblmdb.so => not found",
-            "UnityPlayer.so => /home/user/games/q u d/./UnityPlayer.so (0x00007f90f290f000)"
+            "UnityPlayer.so => /home/user/games/q u d/./UnityPlayer.so"
+            "(0x00007f90f290f000)"
         ]
         # yapf: enable
 


### PR DESCRIPTION
Instead of trying to parse by spaces, this commit implements a parser based on regex. It is separated in two different use cases to not over complicate the parser.

Fix issue #25.