### PR TITLE
Removed hardcoded PATHs in test

### DIFF
--- a/lddwrap/__init__.py
+++ b/lddwrap/__init__.py
@@ -191,7 +191,9 @@ def list_dependencies(path: pathlib.Path,
     """
     Retrieve a list of dependencies of the given binary.
 
-    >>> path = pathlib.Path("/bin/ls")
+    >>> import shutil
+    >>> ls = shutil.which("ls")
+    >>> path = pathlib.Path(ls)
     >>> deps = list_dependencies(path=path)
     >>> deps[0].soname
     'linux-vdso.so.1'

--- a/tests/test_ldd.py
+++ b/tests/test_ldd.py
@@ -11,6 +11,9 @@ import lddwrap
 
 import tests
 
+# Some distros like NixOS does not have binaries on /bin.
+# Instead of hardcoding them, try to get them from PATH
+# using shutil.which function.
 DIR = shutil.which("dir") or "/bin/dir"
 PWD = shutil.which("pwd") or "/bin/pwd"
 

--- a/tests/test_ldd.py
+++ b/tests/test_ldd.py
@@ -2,6 +2,7 @@
 """Test lddwrap."""
 # pylint: disable=missing-docstring,too-many-public-methods
 import pathlib
+import shutil
 import tempfile
 import unittest
 from typing import Any, List, Optional
@@ -9,6 +10,9 @@ from typing import Any, List, Optional
 import lddwrap
 
 import tests
+
+DIR = shutil.which("dir") or "/bin/dir"
+PWD = shutil.which("pwd") or "/bin/pwd"
 
 
 class DependencyDiff:
@@ -187,7 +191,7 @@ class TestAgainstMockLdd(unittest.TestCase):
                 ]),
                 out_unused=''):
             deps = lddwrap.list_dependencies(
-                path=pathlib.Path('/bin/pwd'), unused=False)
+                path=pathlib.Path(PWD), unused=False)
 
             expected_deps = [
                 lddwrap.Dependency(
@@ -236,7 +240,7 @@ class TestAgainstMockLdd(unittest.TestCase):
                 out_unused=''):
             # pylint: enable=line-too-long
             deps = lddwrap.list_dependencies(
-                path=pathlib.Path('/bin/dir'), unused=False)
+                path=pathlib.Path(DIR), unused=False)
 
             expected_deps = [
                 lddwrap.Dependency(
@@ -307,7 +311,7 @@ class TestAgainstMockLdd(unittest.TestCase):
                 out_unused=''):
             # pylint: enable=line-too-long
             deps = lddwrap.list_dependencies(
-                path=pathlib.Path("/bin/dir"), unused=True)
+                path=pathlib.Path(DIR), unused=True)
 
             unused = [dep for dep in deps if dep.unused]
             self.assertListEqual([], unused)
@@ -329,7 +333,7 @@ class TestAgainstMockLdd(unittest.TestCase):
         ):
             # pylint: enable=line-too-long
             deps = lddwrap.list_dependencies(
-                path=pathlib.Path("/bin/dir"), unused=True)
+                path=pathlib.Path(DIR), unused=True)
 
             unused = [dep for dep in deps if dep.unused]
 
@@ -389,7 +393,7 @@ class TestSorting(unittest.TestCase):
 
             for attr in lddwrap.DEPENDENCY_ATTRIBUTES:
                 deps = lddwrap.list_dependencies(
-                    path=pathlib.Path("/bin/dir"), unused=True)
+                    path=pathlib.Path(DIR), unused=True)
 
                 # pylint: disable=protected-access
                 lddwrap._sort_dependencies_in_place(deps=deps, sort_by=attr)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@
 import io
 import json
 import pathlib
+import shutil
 import textwrap
 import unittest
 from typing import List, TextIO, cast
@@ -15,16 +16,18 @@ import pylddwrap_meta
 # pylint: disable=missing-docstring
 import tests
 
+LS = shutil.which("ls") or "/bin/ls"
+PWD = shutil.which("pwd") or "/bin/pwd"
+
 
 class TestParseArgs(unittest.TestCase):
     def test_single_path(self):
-        args = lddwrap.main.parse_args(
-            sys_argv=['some-executable.py', '/bin/ls'])
-        self.assertEqual(pathlib.Path('/bin/ls'), args.path)
+        args = lddwrap.main.parse_args(sys_argv=['some-executable.py', LS])
+        self.assertEqual(pathlib.Path(LS), args.path)
 
     def test_format(self):
         args = lddwrap.main.parse_args(
-            sys_argv=['some-executable.py', '/bin/ls', "--format", "json"])
+            sys_argv=['some-executable.py', LS, "--format", "json"])
         self.assertEqual("json", args.format)
 
 
@@ -116,8 +119,7 @@ class TestMain(unittest.TestCase):
         buf = io.StringIO()
         stream = cast(TextIO, buf)
 
-        args = lddwrap.main.parse_args(
-            sys_argv=["some-executable.py", "/bin/pwd"])
+        args = lddwrap.main.parse_args(sys_argv=["some-executable.py", PWD])
 
         with tests.MockLdd(
                 out="\n".join([
@@ -148,7 +150,7 @@ class TestMain(unittest.TestCase):
         stream = cast(TextIO, buf)
 
         args = lddwrap.main.parse_args(
-            sys_argv=["some-executable.py", "/bin/pwd", "--sorted"])
+            sys_argv=["some-executable.py", PWD, "--sorted"])
 
         with tests.MockLdd(
                 out="\n".join([
@@ -179,7 +181,7 @@ class TestMain(unittest.TestCase):
         stream = cast(TextIO, buf)
 
         args = lddwrap.main.parse_args(
-            sys_argv=["some-executable.py", "/bin/pwd", "--sorted", "path"])
+            sys_argv=["some-executable.py", PWD, "--sorted", "path"])
 
         with tests.MockLdd(
                 out="\n".join([


### PR DESCRIPTION
Some distros like NixOS does not have binaries on `/bin`. Instead of hardcoding them, try to get them from PATH using `shutil.which` function.